### PR TITLE
Fix control flow when fetching the master servers

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -117,10 +117,14 @@ func init() {
 
 	for _, ms := range masterServerHostnameAddresses {
 		srv, err := net.ResolveUDPAddr("udp", ms)
-		if err != nil && Logging {
-			log.Printf("Failed to resolve: %s\n", ms)
+		if err != nil {
+			if Logging {
+				log.Printf("Failed to resolve: %s\n", ms)
+			}
 		} else {
-			log.Printf("Resolved masterserver: %s -> %s\n", ms, srv.String())
+			if Logging {
+				log.Printf("Resolved masterserver: %s -> %s\n", ms, srv.String())
+			}
 			MasterServerAddresses = append(MasterServerAddresses, srv)
 		}
 	}


### PR DESCRIPTION
There are two issues in the init function at the moment which involve
logging:
  1. Current control flow prevents the error condition from ever being run
  2. The logging of master server addresses always occurs even when Logging
     is turned off

Eg.
  ```
srv, err := net.ResolveUDPAddr("udp", ms)

  if err != nil && Logging {
    log.Printf("Failed to resolve: %s\n", ms)
  } else {
    log.Printf("Resolved masterserver: %s -> %s\n", ms, srv.String())
    MasterServerAddresses = append(MasterServerAddresses, srv)
  }
```

If Logging is false, then the else block will always be executed, even
when there is an error.

The log.Printf in the else block will then always be executed, regardless the value of Logging.

A simple fix is to move the Logging check inside each code branch:

Eg.
 ```
 if err != nil {
    if Logging {
      ...
    }
  } else {
    if Logging {
      ...
    }
    MasterServerAddresses = ...
  }
```